### PR TITLE
Add https url for sub-module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "External/computecpp-sdk"]
 	path = External/computecpp-sdk
-	url = git@github.com:codeplaysoftware/computecpp-sdk.git
+	url = https://github.com/codeplaysoftware/computecpp-sdk.git
 [submodule "External/catch2"]
 	path = External/catch2
 	url = https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
If you try to git clone --recursive it needs the https url to avoid the "Permission denied (publickey)."